### PR TITLE
Custom boxart improvements

### DIFF
--- a/core/ui/boxart/boxart.cpp
+++ b/core/ui/boxart/boxart.cpp
@@ -36,6 +36,38 @@ GameBoxart Boxart::getBoxart(const GameMedia& media)
 	return boxart;
 }
 
+bool Boxart::checkCustomBoxart(GameBoxart& boxart)
+{
+	std::string customDir = getCustomBoxartDirectory();
+	
+	if (!file_exists(customDir))
+		make_directory(customDir);
+	
+	std::string baseName = get_file_basename(boxart.fileName);
+	
+	// Check for common image formats
+	const char* extensions[] = { ".png", ".jpg", ".jpeg", ".webp" };
+	
+	for (const char* ext : extensions)
+	{
+		// Make sure we use the correct path separator for the OS
+		std::string customPath = customDir;
+		if (!customPath.empty() && customPath.back() != '/' && customPath.back() != '\\')
+			customPath += '/';
+			
+		customPath += baseName + ext;
+		
+		if (file_exists(customPath))
+		{
+			boxart.setBoxartPath(customPath);
+			boxart.parsed = true;
+			return true;
+		}
+	}
+	
+	return false;
+}
+
 GameBoxart Boxart::getBoxartAndLoad(const GameMedia& media)
 {
 	loadDatabase();
@@ -46,6 +78,15 @@ GameBoxart Boxart::getBoxartAndLoad(const GameMedia& media)
 		if (it != games.end())
 		{
 			boxart = it->second;
+			
+			// Check for custom boxart first
+			if (checkCustomBoxart(boxart))
+			{
+				games[media.fileName] = boxart;
+				databaseDirty = true;
+				return boxart;
+			}
+			
 			if (config::FetchBoxart && !boxart.busy && !boxart.scraped)
 			{
 				boxart.busy = it->second.busy = true;
@@ -59,6 +100,15 @@ GameBoxart Boxart::getBoxartAndLoad(const GameMedia& media)
 			boxart.gamePath = media.path;
 			boxart.name = media.name;
 			boxart.searchName = media.gameName;	// for arcade games
+			
+			// Check for custom boxart
+			if (checkCustomBoxart(boxart))
+			{
+				games[boxart.fileName] = boxart;
+				databaseDirty = true;
+				return boxart;
+			}
+			
 			boxart.busy = true;
 			games[boxart.fileName] = boxart;
 			toFetch.push_back(boxart);
@@ -213,6 +263,11 @@ void Boxart::loadDatabase()
 	} catch (const json::exception& e) {
 		WARN_LOG(COMMON, "Corrupted database file: %s", e.what());
 	}
+	
+	// Create custom boxart directory if it doesn't exist
+	std::string customDir = getCustomBoxartDirectory();
+	if (!file_exists(customDir))
+		make_directory(customDir);
 }
 
 void Boxart::term()

--- a/core/ui/boxart/boxart.h
+++ b/core/ui/boxart/boxart.h
@@ -35,6 +35,14 @@ public:
 	GameBoxart getBoxartAndLoad(const GameMedia& media);
 	GameBoxart getBoxart(const GameMedia& media);
 	void term();
+	std::string getCustomBoxartPath() const {
+		std::string path = get_writable_data_path("/custom_boxart/");
+		// Convert backslashes to forward slashes for display consistency
+		for (char& c : path)
+			if (c == '\\')
+				c = '/';
+		return path;
+	}
 
 private:
 	void loadDatabase();
@@ -42,6 +50,10 @@ private:
 	std::string getSaveDirectory() const {
 		return get_writable_data_path("/boxart/");
 	}
+	std::string getCustomBoxartDirectory() const {
+		return get_writable_data_path("/custom_boxart/");
+	}
+	bool checkCustomBoxart(GameBoxart& boxart);
 	void fetchBoxart();
 
 	std::unordered_map<std::string, GameBoxart> games;

--- a/core/ui/boxart/scraper.h
+++ b/core/ui/boxart/scraper.h
@@ -92,8 +92,12 @@ struct GameBoxart
 	}
 
 	void setBoxartPath(const std::string& path) {
-		if (!boxartPath.empty())
-			nowide::remove(boxartPath.c_str());
+		if (!boxartPath.empty() && boxartPath != path) {
+			// Don't delete files in the custom_boxart directory
+			if (boxartPath.find("/custom_boxart/") == std::string::npos && 
+				boxartPath.find("\\custom_boxart\\") == std::string::npos)
+				nowide::remove(boxartPath.c_str());
+		}
 		boxartPath = path;
 	}
 };

--- a/core/ui/gui.cpp
+++ b/core/ui/gui.cpp
@@ -1858,6 +1858,36 @@ static void gui_settings_general()
 			"Display game cover art in the game list.");
 	OptionCheckbox("Fetch Box Art", config::FetchBoxart,
 			"Fetch cover images from TheGamesDB.net.");
+	
+	if (ImGui::TreeNode("Custom Boxart"))
+	{
+		std::string customDir = get_writable_data_path("/custom_boxart/");
+		if (!file_exists(customDir))
+			make_directory(customDir);
+		
+		// Convert backslashes to forward slashes for display consistency
+		std::string displayPath = customDir;
+		for (char& c : displayPath)
+			if (c == '\\')
+				c = '/';
+		
+		ImGui::TextWrapped("To use custom boxart, place image files in the following folder:");
+		ImGui::TextWrapped("%s", displayPath.c_str());
+		ImGui::Separator();
+		ImGui::TextWrapped("Name your image files using the game filename (without extension).");
+		ImGui::TextWrapped("Supported formats: PNG, JPG, JPEG, WEBP");
+		ImGui::TextWrapped("Example: For 'Sonic Adventure.gdi', use 'Sonic Adventure.png'");
+		
+		if (ImGui::Button("Refresh Custom Boxart"))
+		{
+			// Reset boxart database to force reload
+			boxart.term();
+			scanner.refresh();
+		}
+		
+		ImGui::TreePop();
+	}
+	
 	if (OptionSlider("UI Scaling", config::UIScaling, 50, 200, "Adjust the size of UI elements and fonts.", "%d%%"))
 		uiUserScaleUpdated = true;
 	if (uiUserScaleUpdated)

--- a/core/ui/gui.cpp
+++ b/core/ui/gui.cpp
@@ -1878,13 +1878,6 @@ static void gui_settings_general()
 		ImGui::TextWrapped("Supported formats: PNG, JPG, JPEG, WEBP");
 		ImGui::TextWrapped("Example: For 'Sonic Adventure.gdi', use 'Sonic Adventure.png'");
 		
-		if (ImGui::Button("Refresh Custom Boxart"))
-		{
-			// Reset boxart database to force reload
-			boxart.term();
-			scanner.refresh();
-		}
-		
 		ImGui::TreePop();
 	}
 	


### PR DESCRIPTION
added the ability to simply add custom boxart for your library.

Creats a cusotm folder, flycast/data/custom_boxart.

Simlply rename the image (without the extension) and it will instantly apply.

added a simple instruction set in the General Tab.