### PR TITLE
Add custom box art override support

### DIFF
--- a/core/cfg/option.cpp
+++ b/core/cfg/option.cpp
@@ -39,6 +39,7 @@ Option<int, false> SavestateSlot("Dreamcast.SavestateSlot");
 Option<bool> ForceFreePlay("ForceFreePlay", true);
 Option<bool, false> FetchBoxart("FetchBoxart", true);
 Option<bool, false> BoxartDisplayMode("BoxartDisplayMode", true);
+OptionString CustomBoxartPath("Boxart.CustomPath");
 Option<int, false> UIScaling("UIScaling", 100);
 Option<int, false> UITheme("UITheme", 0);
 

--- a/core/cfg/option.h
+++ b/core/cfg/option.h
@@ -366,6 +366,7 @@ extern Option<int, false> SavestateSlot;
 extern Option<bool> ForceFreePlay;
 extern Option<bool, false> FetchBoxart;
 extern Option<bool, false> BoxartDisplayMode;
+extern OptionString CustomBoxartPath;
 extern Option<int, false> UIScaling;
 extern Option<int, false> UITheme;          // 0 -> Dark, 1 -> Light, 2 -> Dreamcast, 3 -> High Contrast, 4 -> Nintendo, 5 -> Aqua Chill
 

--- a/core/ui/boxart/boxart.cpp
+++ b/core/ui/boxart/boxart.cpp
@@ -22,7 +22,49 @@
 #include "oslib/oslib.h"
 #include "cfg/option.h"
 #include "arcade_scraper.h"
+#include <array>
 #include <chrono>
+
+static std::string getCustomBoxartDirectory()
+{
+	std::string customPath = config::CustomBoxartPath.get();
+	if (customPath.empty())
+	{
+		customPath = get_writable_data_path("/boxart/custom/");
+	}
+	else if (customPath.back() != '/' && customPath.back() != '\')
+		customPath += '/';
+	if (!file_exists(customPath))
+		make_directory(customPath);
+	return customPath;
+}
+
+static bool applyCustomBoxart(GameBoxart& boxart)
+{
+	if (boxart.fileName.empty())
+		return false;
+	const std::string customDir = getCustomBoxartDirectory();
+	const std::array<std::string, 6> extensions{ "png", "jpg", "jpeg", "PNG", "JPG", "JPEG" };
+	const std::array<std::string, 2> names{ get_file_basename(boxart.fileName), boxart.fileName };
+	for (const auto& name : names)
+	{
+		if (name.empty())
+			continue;
+		for (const auto& ext : extensions)
+		{
+			std::string path = customDir + name + "." + ext;
+			if (file_exists(path))
+			{
+				boxart.boxartPath = path;
+				boxart.busy = false;
+				boxart.scraped = true;
+				boxart.parsed = true;
+				return true;
+			}
+		}
+	}
+	return false;
+}
 
 GameBoxart Boxart::getBoxart(const GameMedia& media)
 {
@@ -32,7 +74,14 @@ GameBoxart Boxart::getBoxart(const GameMedia& media)
 		std::lock_guard<std::mutex> guard(mutex);
 		auto it = games.find(media.fileName);
 		if (it != games.end())
+		{
 			boxart = it->second;
+			if (applyCustomBoxart(boxart))
+			{
+				games[boxart.fileName] = boxart;
+				databaseDirty = true;
+			}
+		}
 	}
 	return boxart;
 }
@@ -41,19 +90,13 @@ GameBoxart Boxart::getBoxartAndLoad(const GameMedia& media)
 {
 	loadDatabase();
 	GameBoxart boxart;
+	bool scheduleFetch = false;
 	{
 		std::lock_guard<std::mutex> guard(mutex);
 		auto it = games.find(media.fileName);
 		if (it != games.end())
 		{
 			boxart = it->second;
-			if (config::FetchBoxart && !boxart.busy && !boxart.scraped)
-			{
-				boxart.busy = it->second.busy = true;
-				boxart.gamePath = media.path;
-				boxart.arcade = media.arcade;
-				toFetch.push_back(boxart);
-			}
 		}
 		else
 		{
@@ -63,9 +106,27 @@ GameBoxart Boxart::getBoxartAndLoad(const GameMedia& media)
 			boxart.searchName = media.gameName;	// for arcade games
 			boxart.busy = true;
 			boxart.arcade = media.arcade;
-			games[boxart.fileName] = boxart;
-			toFetch.push_back(boxart);
+			it = games.emplace(boxart.fileName, boxart).first;
+			scheduleFetch = true;
 		}
+		if (applyCustomBoxart(boxart))
+		{
+			boxart.gamePath = media.path;
+			boxart.arcade = media.arcade;
+			it->second = boxart;
+			databaseDirty = true;
+			scheduleFetch = false;
+		}
+		if (config::FetchBoxart && !boxart.busy && !boxart.scraped)
+		{
+			boxart.busy = true;
+			boxart.gamePath = media.path;
+			boxart.arcade = media.arcade;
+			it->second = boxart;
+			scheduleFetch = true;
+		}
+		if (scheduleFetch)
+			toFetch.push_back(boxart);
 	}
 	fetchBoxart();
 	return boxart;

--- a/core/ui/boxart/boxart.cpp
+++ b/core/ui/boxart/boxart.cpp
@@ -27,16 +27,18 @@
 
 static std::string getCustomBoxartDirectory()
 {
-	std::string customPath = config::CustomBoxartPath.get();
-	if (customPath.empty())
-	{
-		customPath = get_writable_data_path("/boxart/custom/");
-	}
-	else if (customPath.back() != '/' && customPath.back() != '\')
-		customPath += '/';
-	if (!file_exists(customPath))
-		make_directory(customPath);
-	return customPath;
+        std::string customPath = config::CustomBoxartPath.get();
+        if (customPath.empty())
+        {
+                customPath = get_writable_data_path("/boxart/custom/");
+        }
+        else if (customPath.back() != '/' && customPath.back() != '\\')
+        {
+                customPath += '/';
+        }
+        if (!file_exists(customPath))
+                make_directory(customPath);
+        return customPath;
 }
 
 static bool applyCustomBoxart(GameBoxart& boxart)

--- a/core/ui/settings_general.cpp
+++ b/core/ui/settings_general.cpp
@@ -207,11 +207,10 @@ void gui_settings_general()
                         "Display game cover art in the game list.");
         OptionCheckbox("Fetch Box Art", config::FetchBoxart,
                         "Fetch cover images from TheGamesDB.net.");
-        ImGui::TextWrapped("Drop PNG, JPG, or JPEG files named after the game into the custom folder below to override scraped bo"
-                           "x art.");
+        ImGui::TextWrapped("Place PNG or JPG images named exactly as the ROM file's named to update library box art images in new folder. Put folder path below.");
         ImGui::InputText("Custom Box Art Folder", &config::CustomBoxartPath.get());
         ImGui::SameLine();
-        ShowHelpMarker("Override box art with user images in this folder. Use PNG, JPG, or JPEG named after the game file or base name.");
+        ShowHelpMarker("Override box art with user images in this folder. Make a folder and place full path here.");
         if (OptionSlider("UI Scaling", config::UIScaling, 50, 200, "Adjust the size of UI elements and fonts.", "%d%%"))
                 uiUserScaleUpdated = true;
         if (uiUserScaleUpdated)

--- a/core/ui/settings_general.cpp
+++ b/core/ui/settings_general.cpp
@@ -203,15 +203,18 @@ void gui_settings_general()
     }
 #endif
 
-	OptionCheckbox("Box Art Game List", config::BoxartDisplayMode,
-			"Display game cover art in the game list.");
-	OptionCheckbox("Fetch Box Art", config::FetchBoxart,
-			"Fetch cover images from TheGamesDB.net.");
-	if (OptionSlider("UI Scaling", config::UIScaling, 50, 200, "Adjust the size of UI elements and fonts.", "%d%%"))
-		uiUserScaleUpdated = true;
-	if (uiUserScaleUpdated)
-	{
-		ImGui::SameLine();
+        OptionCheckbox("Box Art Game List", config::BoxartDisplayMode,
+                        "Display game cover art in the game list.");
+        OptionCheckbox("Fetch Box Art", config::FetchBoxart,
+                        "Fetch cover images from TheGamesDB.net.");
+        ImGui::InputText("Custom Box Art Folder", &config::CustomBoxartPath.get());
+        ImGui::SameLine();
+        ShowHelpMarker("Override box art with user images in this folder. Use PNG, JPG, or JPEG named after the game file or base name.");
+        if (OptionSlider("UI Scaling", config::UIScaling, 50, 200, "Adjust the size of UI elements and fonts.", "%d%%"))
+                uiUserScaleUpdated = true;
+        if (uiUserScaleUpdated)
+        {
+                ImGui::SameLine();
 		if (ImGui::Button("Apply")) {
 			mainui_reinit();
 			uiUserScaleUpdated = false;

--- a/core/ui/settings_general.cpp
+++ b/core/ui/settings_general.cpp
@@ -207,6 +207,8 @@ void gui_settings_general()
                         "Display game cover art in the game list.");
         OptionCheckbox("Fetch Box Art", config::FetchBoxart,
                         "Fetch cover images from TheGamesDB.net.");
+        ImGui::TextWrapped("Drop PNG, JPG, or JPEG files named after the game into the custom folder below to override scraped bo"
+                           "x art.");
         ImGui::InputText("Custom Box Art Folder", &config::CustomBoxartPath.get());
         ImGui::SameLine();
         ShowHelpMarker("Override box art with user images in this folder. Use PNG, JPG, or JPEG named after the game file or base name.");


### PR DESCRIPTION
## Summary
- add a configurable custom box art folder option in settings
- prefer user-provided box art images before scraping existing sources
- persist custom selections and avoid unnecessary scraping when overrides exist

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691cd51f2f6c832680383f81f30b0063)