### PR TITLE
Fix custom boxart trailing separator check

### DIFF
--- a/core/ui/boxart/boxart.cpp
+++ b/core/ui/boxart/boxart.cpp
@@ -36,6 +36,13 @@ static bool isContentUri(const std::string& path)
 #endif
 }
 
+static bool hasTrailingSeparator(const std::string& path)
+{
+	if (path.empty())
+		return false;
+	return path.find_last_of("/\\") == path.size() - 1;
+}
+
 static std::string getCustomBoxartDirectory()
 {
 	std::string customPath = config::CustomBoxartPath.get();
@@ -43,7 +50,7 @@ static std::string getCustomBoxartDirectory()
 	{
 		customPath = get_writable_data_path("/boxart/custom/");
 	}
-	else if (!isContentUri(customPath) && customPath.back() != '/' && customPath.back() != '\')
+	else if (!isContentUri(customPath) && !hasTrailingSeparator(customPath))
 	{
 		customPath += '/';
 	}


### PR DESCRIPTION
## Summary
- add a helper to detect trailing path separators for custom boxart locations
- use the helper when normalizing custom boxart paths to avoid invalid character literals

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923e6cca5cc8326b3b938a45cfd48fe)