### PR TITLE
Adjust vgamepad texture cache override

### DIFF
--- a/core/cfg/option.cpp
+++ b/core/cfg/option.cpp
@@ -229,3 +229,5 @@ OptionString AchievementsUserName("UserName", "", "achievements");
 OptionString AchievementsToken("Token", "", "achievements");
 
 } // namespace config
+
+

--- a/core/ui/vgamepad.cpp
+++ b/core/ui/vgamepad.cpp
@@ -159,16 +159,20 @@ static ImTextureID loadOSDButtons()
 
 ImTextureID ImguiVGamepadTexture::getId()
 {
-	ImTextureID id = imguiDriver->getTexture(getButtonsResPath());
-	if (id == ImTextureID())
-		id = loadOSDButtons();
+        ImTextureID id = imguiDriver->getTexture(getButtonsResPath());
+        if (id == ImTextureID())
+                id = loadOSDButtons();
 
-	return id;
+        return id;
+}
+
+void ImguiVGamepadTexture::deleteCache()
+{
 }
 
 constexpr float vjoy_tex[_Count][4] = {
-	// L
-	{   0,   0,  64,  64 },
+        // L
+        {   0,   0,  64,  64 },
 	// U
 	{  64,   0,  64,  64 },
 	// R

--- a/core/ui/vgamepad.h
+++ b/core/ui/vgamepad.h
@@ -73,7 +73,8 @@ enum Element
 class ImguiVGamepadTexture : public ImguiTexture
 {
 public:
-	ImTextureID getId() override;
+        ImTextureID getId() override;
+        void deleteCache() override;
 };
 
 #if defined(__ANDROID__) || defined(TARGET_IPHONE)


### PR DESCRIPTION
## Summary
- keep the virtual gamepad texture cache override minimal to satisfy the interface without altering texture state

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928fa92499c8326857e77b1018f06a6)